### PR TITLE
Remove deprecated apigw-compat.tf file

### DIFF
--- a/test/folder/file.tf
+++ b/test/folder/file.tf
@@ -1,1 +1,0 @@
-test-file


### PR DESCRIPTION
This PR removes the deprecated apigw-compat.tf file as part of our infrastructure cleanup efforts.